### PR TITLE
feat: add show-console option to control console window visibility

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,6 +24,7 @@ sha1 = "0.10.6"
 [target.'cfg(target_os = "windows")'.dependencies]
 nwg = {package = "native-windows-gui", version = "1.0.13"}
 nwd = {package = "native-windows-derive", version = "1.0.5"}
+winapi = {version = "0.3", features = ["winuser", "libloaderapi", "consoleapi", "processenv", "winbase", "wincon"]}
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 embed-resource = "2.4"

--- a/client/src/global_config.rs
+++ b/client/src/global_config.rs
@@ -107,6 +107,12 @@ pub struct GlobalConfig {
     /// http/webdav协议是否忽略SSL证书验证
     #[default_value("false")]
     pub http_ignore_certificate: bool,
+
+    /// 是否显示控制台（黑窗口）
+    /// 如果为false，程序启动时不会显示控制台窗口
+    /// 如果为true，会显示控制台窗口，方便调试
+    #[default_value("false")]
+    pub show_console: bool,
 }
 
 impl GlobalConfig {
@@ -177,6 +183,7 @@ impl GlobalConfig {
         let http_timeout = config["http-timeout"].as_i64().be(|| "配置文件中找不到 http-timeout")? as u32;
         let http_retries = config["http-retries"].as_i64().be(|| "配置文件中找不到 http-retries")? as u8;
         let http_ignore_certificate = config["http-ignore-certificate"].as_bool().be(|| "配置文件中找不到 http-ignore-certificate")?.to_owned();
+        let show_console = config["show-console"].as_bool().be(|| "配置文件中找不到 show-console")?.to_owned();
 
         Ok(GlobalConfig {
             urls,
@@ -193,6 +200,7 @@ impl GlobalConfig {
             http_timeout,
             http_retries,
             http_ignore_certificate,
+            show_console,
         })
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -39,7 +39,10 @@ pub struct McpatchExitCode(pub i8);
 
 pub fn program() -> McpatchExitCode {
     std::env::set_var("RUST_BACKTRACE", "1");
-    
+
+    #[cfg(target_os = "windows")]
+    hide_console_initial();
+
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
         .enable_all()
@@ -126,6 +129,35 @@ pub fn program() -> McpatchExitCode {
     {
         // 开始执行更新逻辑
         return runtime.block_on(run(params, ()));
+    }
+}
+
+/// 在程序启动时立即隐藏控制台窗口
+/// 后续会根据配置决定是否重新显示
+#[cfg(target_os = "windows")]
+fn hide_console_initial() {
+    use winapi::um::wincon::GetConsoleWindow;
+    use winapi::um::winuser::{ShowWindow, SW_HIDE};
+
+    unsafe {
+        let hwnd = GetConsoleWindow();
+        if !hwnd.is_null() {
+            ShowWindow(hwnd, SW_HIDE);
+        }
+    }
+}
+
+/// 根据配置显示或隐藏控制台窗口
+#[cfg(target_os = "windows")]
+pub fn apply_console_visibility(show: bool) {
+    use winapi::um::wincon::GetConsoleWindow;
+    use winapi::um::winuser::{ShowWindow, SW_HIDE, SW_SHOW};
+
+    unsafe {
+        let hwnd = GetConsoleWindow();
+        if !hwnd.is_null() {
+            ShowWindow(hwnd, if show { SW_SHOW } else { SW_HIDE });
+        }
     }
 }
 

--- a/client/src/work.rs
+++ b/client/src/work.rs
@@ -107,6 +107,10 @@ pub async fn work(params: &StartupParameter, ui_cmd: UiCmd<'_>, allow_error: &mu
 
     *allow_error = config.allow_error;
 
+    // 根据配置显示或隐藏控制台窗口
+    #[cfg(target_os = "windows")]
+    crate::apply_console_visibility(config.show_console);
+
     let log_file_path = match params.graphic_mode {
         true => exe_dir.join("mcpatch.log"),
         false => exe_dir.join("mcpatch.log.txt"),


### PR DESCRIPTION
## Description

Adds a `show-console` configuration option to `mcpatch.yml` that allows users to control whether the console window is displayed.

This is useful for:
- End users: default `false` → clean experience without a black console
- Developers/debugging: set `true` to see console output

## Changes

| File | Change |
|------|--------|
| `client/Cargo.toml` | Add winapi dependency (windows-only) |
| `client/src/global_config.rs` | Add `show_console` field + parsing |
| `client/src/lib.rs` | Add `hide_console_initial()` + `apply_console_visibility()` |
| `client/src/work.rs` | Apply console visibility after config load |

## Configuration

\`\`\`yaml
# Whether to show the console window
# false: hide console (default)
# true:  show console for debugging
show-console: false
\`\`\`

## Testing

- [x] Compiles successfully (\`cargo build --release -p client\`)
- [x] Compiles successfully (\`cargo build -p client\`)
- [x] Default config hides console on startup
- [ ] \`show-console: true\` shows console (manual test)

Tested on both Debug and Release profiles on Windows.

## Notes

The console is hidden in two phases:
1. Before any UI initialization, to prevent any visible flicker
2. After config is loaded, to respect the user\s preference