### PR TITLE
feat: add run-after-update option to launch program after update

### DIFF
--- a/client/src/global_config.rs
+++ b/client/src/global_config.rs
@@ -107,6 +107,12 @@ pub struct GlobalConfig {
     /// http/webdav协议是否忽略SSL证书验证
     #[default_value("false")]
     pub http_ignore_certificate: bool,
+
+    /// 更新完成后要启动的程序路径
+    /// 留空表示不启动任何程序
+    /// 示例：Plain Craft Launcher 2.exe
+    #[default_value("''")]
+    pub run_after_update: String,
 }
 
 impl GlobalConfig {
@@ -177,6 +183,7 @@ impl GlobalConfig {
         let http_timeout = config["http-timeout"].as_i64().be(|| "配置文件中找不到 http-timeout")? as u32;
         let http_retries = config["http-retries"].as_i64().be(|| "配置文件中找不到 http-retries")? as u8;
         let http_ignore_certificate = config["http-ignore-certificate"].as_bool().be(|| "配置文件中找不到 http-ignore-certificate")?.to_owned();
+        let run_after_update = config["run-after-update"].as_str().be(|| "配置文件中找不到 run-after-update")?.to_owned();
 
         Ok(GlobalConfig {
             urls,
@@ -193,6 +200,7 @@ impl GlobalConfig {
             http_timeout,
             http_retries,
             http_ignore_certificate,
+            run_after_update,
         })
     }
 }

--- a/client/src/work.rs
+++ b/client/src/work.rs
@@ -666,6 +666,13 @@ pub async fn work(params: &StartupParameter, ui_cmd: UiCmd<'_>, allow_error: &mu
         }
     }
 
+    // Launch the configured program after update completes
+    if !config.run_after_update.is_empty() {
+        log_info(format!("Update complete, launching: {}", config.run_after_update));
+        let _ = std::process::Command::new(&config.run_after_update)
+            .spawn();
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Description

Adds a `run-after-update` configuration option to `mcpatch.yml` that specifies a program to launch automatically after the update process completes.

This is particularly useful for launching PCL2 or other Minecraft launchers immediately after updating modpack files, providing a seamless end-to-end update-and-launch experience.

## Changes

| File | Change |
|------|--------|
| `client/src/global_config.rs` | Add `run_after_update` field + parsing |
| `client/src/work.rs` | Spawn configured program after update completes |

## Configuration

\`\`\`yaml
# Program to launch after update completes
# Leave empty to do nothing
# Example: "Plain Craft Launcher 2.exe"
run-after-update: ""
\`\`\`

## Testing

- [x] Compiles successfully (\`cargo build --release -p client\`)
- [x] Compiles successfully (\`cargo build -p client\`)
- [ ] Launch works correctly with a real launcher (manual test)

Tested on both Debug and Release profiles on Windows.

## Notes

The program is spawned via \`std::process::Command::new(...).spawn()\` after the update workflow returns \`Ok(())\`. If the program path is invalid, the error is silently ignored to avoid interrupting the update flow. The spawned program runs in the background and does not block the update exit.